### PR TITLE
Gcp 24 dont rely on node rel types

### DIFF
--- a/cloudify_gcp/compute/subnetwork.py
+++ b/cloudify_gcp/compute/subnetwork.py
@@ -163,14 +163,20 @@ def creation_validation(**kwargs):
     if not ctx.node.properties['region']:
         raise NonRecoverableError("region must be supplied")
 
-    types = ('cloudify.gcp.relationships.contained_in_network',
-             'cloudify.gcp.nodes.Network')
-    rels = utils.get_relationships(ctx, *types)
+    rel_type = 'cloudify.gcp.relationships.contained_in_network'
+    node_type = 'cloudify.gcp.nodes.Network'
+
+    rels = utils.get_relationships(
+            ctx,
+            filter_relationships=[rel_type])
 
     if len(rels) != 1:
         raise NonRecoverableError(
-                "SubNetwork must be contained in a '{1}' using the '{0}' "
-                "relationship".format(*types))
+                "SubNetwork must be contained in a '{node}' "
+                "using the '{rel}' relationship".format(
+                    node=node_type,
+                    rel=rel_type,
+                    ))
 
     if not ctx.node.properties['use_external_resource']:
         network = rels[0].target

--- a/cloudify_gcp/compute/tests/test_disk.py
+++ b/cloudify_gcp/compute/tests/test_disk.py
@@ -27,8 +27,14 @@ from ...tests import TestGCP
 class TestGCPDisk(TestGCP):
 
     def test_create(self, mock_build, *args):
+        mock_build().globalOperations().get().execute.side_effect = [
+                {'status': 'PENDING', 'name': 'Dave'},
+                {'status': 'DONE', 'name': 'Dave'},
+                ]
+
         disk.create(
                 'image', 'name', 'size',
+                boot=False,
                 additional_settings={},
                 )
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -203,6 +203,11 @@ node_types:
           Size of the Volume in GB.
         type: integer
         default: 10
+      boot:
+        description: >
+          Will this disk be the boot disk for the Instance it is connected to?
+        type: boolean
+        default: no
       additional_settings:
         description: >
           Additional setting for volume
@@ -218,6 +223,8 @@ node_types:
               default: { get_property: [SELF, name] }
             size:
               default: { get_property: [SELF, size] }
+            boot:
+              default: { get_property: [SELF, boot] }
             additional_settings:
               default: { get_property: [SELF, additional_settings]}
         delete:
@@ -1099,13 +1106,6 @@ relationships:
           inputs:
             instance_name:
               default: { get_attribute: [SOURCE, name] }
-
-  cloudify.gcp.relationships.file_system_contained_in_compute:
-    derived_from: cloudify.relationships.contained_in
-    target_interfaces:
-      cloudify.interfaces.relationship_lifecycle:
-        preconfigure:
-          implementation: gcp_plugin.cloudify_gcp.compute.disk.add_boot_disk
 
   cloudify.gcp.relationships.instance_connected_to_disk:
     derived_from: cloudify.relationships.connected_to

--- a/system_tests/local/__init__.py
+++ b/system_tests/local/__init__.py
@@ -121,3 +121,6 @@ class GCPTest(object):
 
         if match:
             self.assertRegexpMatches(ip, match)
+
+    def get_instance(self, node):
+        return self.test_env.storage.get_node_instances(node)[0]

--- a/system_tests/local/test_disk.py
+++ b/system_tests/local/test_disk.py
@@ -1,0 +1,36 @@
+########
+# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+from cosmo_tester.framework.testenv import TestCase
+
+from . import GCPTest
+
+
+class GCPDiskTest(GCPTest, TestCase):
+    blueprint_name = 'disk/attach-disk.yaml'
+
+    inputs = (
+            'project',
+            'network',
+            'zone',
+            'gcp_auth',
+            'image_id',
+            )
+
+    def assertions(self):
+        self.assertEqual(
+            self.get_instance('vm')[
+                'runtime_properties']['disks'][0]['source'],
+            self.get_instance('boot_disk')['runtime_properties']['selfLink'])

--- a/system_tests/resources/disk/attach-disk.yaml
+++ b/system_tests/resources/disk/attach-disk.yaml
@@ -1,0 +1,49 @@
+tosca_definitions_version: cloudify_dsl_1_3
+
+
+imports:
+  - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
+  - ../../../plugin.yaml
+
+
+inputs:
+  gcp_auth:
+  project:
+  network:
+  zone:
+
+  image_id:
+    default: https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160803
+    required: true
+
+
+dsl_definitions:
+  - &gcp_config
+    auth: { get_input: gcp_auth }
+    project: { get_input: project }
+    network: { get_input: network }
+    zone: { get_input: zone }
+
+
+node_templates:
+  vm:
+    type: cloudify.gcp.nodes.Instance
+    properties:
+      external_ip: true
+      gcp_config: *gcp_config
+      install_agent: false
+    relationships:
+      - type: cloudify.relationships.connected_to
+        target: boot_disk
+
+  boot_disk:
+    type: cloudify.gcp.nodes.Volume
+    properties:
+      image: { get_input: image_id }
+      boot: true
+      gcp_config: *gcp_config
+
+
+outputs:
+  ip:
+    value: {get_attribute: [vm, ip]}

--- a/system_tests/resources/networks/external-networks-blueprint.yaml
+++ b/system_tests/resources/networks/external-networks-blueprint.yaml
@@ -81,7 +81,7 @@ node_templates:
       install_agent: false
       gcp_config: *gcp_config
     relationships:
-      - type: cloudify.gcp.relationships.contained_in_network
+      - type: cloudify.relationships.connected_to
         target: subnet_2
 
 


### PR DESCRIPTION
Opening this so it's tracked but this is in the wrong place in the tree

Too many overlapping changes to reasonably do this until the others are merged. Then it can be rebased

JIRA: GCP-24