### PR TITLE
Fix new startup script tests

### DIFF
--- a/cloudify_gcp/compute/tests/test_instance.py
+++ b/cloudify_gcp/compute/tests/test_instance.py
@@ -15,7 +15,6 @@
 #    * limitations under the License.
 
 from functools import partial
-from unittest import TestCase
 
 from mock import patch, Mock
 
@@ -29,37 +28,6 @@ utils_get_ssh_keys_patch = partial(
         patch,
         'cloudify_gcp.utils.get_agent_ssh_key_string',
         )
-
-
-class TestHelpers(TestCase):
-
-    def test__get_script_string(self):
-        response = instance._get_script({
-            'type': 'string',
-            'script': '📜',
-            })
-        new_script_format = {
-            'key': 'startup-script',
-            'value': '📜'
-        }
-        self.assertEqual(new_script_format, response)
-
-    def test__get_script_bare_string_old_format_input(self):
-        new_script_format = {
-            'key': 'startup-script',
-            'value': '🐻'
-        }
-        self.assertEqual(new_script_format, instance._get_script('🐻'))
-
-    def test__get_script_bare_string_new_format_input(self):
-        new_script_format = {
-            'key': 'startup-script',
-            'value': '🐻'
-        }
-        self.assertEqual(new_script_format,
-                         instance._get_script({
-                                'key': 'startup-script',
-                                'value': '🐻'}))
 
 
 @patch('cloudify_gcp.gcp.ServiceAccountCredentials.from_json_keyfile_dict')
@@ -89,6 +57,34 @@ class TestGCPInstance(TestGCP):
             })
 
         self.ctxmock.get_resource.assert_called_once_with('/dev/null')
+
+    def test__get_script_string(self, *_):
+        response = instance._get_script({
+            'type': 'string',
+            'script': '📜',
+            })
+        new_script_format = {
+            'key': 'startup-script',
+            'value': '📜'
+        }
+        self.assertEqual(new_script_format, response)
+
+    def test__get_script_bare_string_old_format_input(self, *_):
+        new_script_format = {
+            'key': 'startup-script',
+            'value': '🐻'
+        }
+        self.assertEqual(new_script_format, instance._get_script('🐻'))
+
+    def test__get_script_bare_string_new_format_input(self, *_):
+        new_script_format = {
+            'key': 'startup-script',
+            'value': '🐻'
+        }
+        self.assertEqual(new_script_format,
+                         instance._get_script({
+                                'key': 'startup-script',
+                                'value': '🐻'}))
 
     def test_create(self, mock_build, *args):
         self.ctxmock.instance.runtime_properties.update({

--- a/cloudify_gcp/tests/__init__.py
+++ b/cloudify_gcp/tests/__init__.py
@@ -46,3 +46,6 @@ class TestGCP(unittest.TestCase):
         ctx.instance.runtime_properties = DirtyTrackingDict()
         ctx.instance.relationships = []
         current_ctx.set(ctx)
+
+    def tearDown(self):
+        current_ctx.clear()


### PR DESCRIPTION
(_get_script requires the ctx now, so the separate class caused
failures, which were masked by the ctx leaking from other tests.
pytest's test order is different to nose, so they were exposed by switching to pytest)