### PR TITLE
Fix-Typos

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+1.8.7: Fix issues from deprecate.
 1.8.6: Deprecate old node types.
 1.8.5: release redhat8 wagon and dsl 1_4 yaml.
 1.8.4: Resource tags.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@ plugins:
   gcp_plugin:
     executor: central_deployment_agent
     package_name: cloudify-gcp-plugin
-    package_version: '1.8.6'
+    package_version: '1.8.7'
 
 dsl_definitions:
   use_external_resource_desc: &use_external_resource_desc >
@@ -41,7 +41,7 @@ dsl_definitions:
 
 node_types:
 
-  cloudify.gcp.project:
+  cloudify.nodes.gcp.project:
     derived_from: cloudify.nodes.Root
     properties:
       <<: *external_resource
@@ -63,6 +63,12 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.admin.projects.create
         delete:
           implementation: gcp_plugin.cloudify_gcp.admin.projects.delete
+
+  cloudify.gcp.project:
+    derived_from: cloudify.nodes.gcp.project
+
+  cloudify.gcp.nodes.project:
+    derived_from: cloudify.nodes.gcp.project
 
   cloudify.nodes.gcp.PolicyBinding:
     derived_from: cloudify.nodes.Root
@@ -95,6 +101,9 @@ node_types:
               default: { get_property: [SELF, resource]}
             policy:
               default: { get_property: [SELF, policy]}
+
+  cloudify.gcp.nodes.PolicyBinding:
+    derived_from: cloudify.nodes.gcp.PolicyBinding
 
   cloudify.nodes.gcp.Instance:
     derived_from: cloudify.nodes.Compute
@@ -218,6 +227,9 @@ node_types:
             zone:
               default: { get_attribute: [SELF, zone]}
 
+  cloudify.gcp.nodes.Instance:
+    derived_from: cloudify.nodes.gcp.Instance
+
   cloudify.nodes.gcp.InstanceGroup:
     derived_from: cloudify.nodes.Root
     properties:
@@ -251,6 +263,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.instance_group.delete
+
+  cloudify.gcp.nodes.InstanceGroup:
+    derived_from: cloudify.nodes.gcp.InstanceGroup
 
   cloudify.nodes.gcp.Volume:
     derived_from: cloudify.nodes.Volume
@@ -299,6 +314,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.disk.delete
 
+  cloudify.gcp.nodes.Volume:
+    derived_from: cloudify.nodes.gcp.Volume
+
   cloudify.nodes.gcp.Snapshot:
     derived_from: cloudify.nodes.Root
     properties:
@@ -319,6 +337,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.snapshot.delete
           inputs: {}
+
+  cloudify.gcp.nodes.Snapshot:
+    derived_from: cloudify.nodes.gcp.Snapshot
 
   cloudify.nodes.gcp.Network:
     derived_from: cloudify.nodes.Network
@@ -355,6 +376,9 @@ node_types:
           inputs:
             name:
               default: { get_property: [SELF, name] }
+
+  cloudify.gcp.nodes.Network:
+    derived_from: cloudify.nodes.gcp.Network
 
   cloudify.nodes.gcp.SubNetwork:
     derived_from: cloudify.nodes.Subnet
@@ -394,6 +418,9 @@ node_types:
       cloudify.interfaces.validation:
         create:
           implementation: gcp_plugin.cloudify_gcp.compute.subnetwork.creation_validation
+
+  cloudify.gcp.nodes.SubNetwork:
+    derived_from: cloudify.nodes.gcp.SubNetwork
 
   cloudify.nodes.gcp.VPCNetworkPeering:
     derived_from: cloudify.nodes.Network
@@ -435,6 +462,9 @@ node_types:
               default: { get_property: [SELF, network] }
             peerNetwork:
               default: { get_property: [SELF, peerNetwork] }
+
+  cloudify.gcp.nodes.VPCNetworkPeering:
+    derived_from: cloudify.nodes.gcp.VPCNetworkPeering
 
   cloudify.nodes.gcp.Route:
     derived_from: cloudify.nodes.Router
@@ -487,6 +517,9 @@ node_types:
           inputs:
             name:
               default: { get_attribute: [SELF, name] }
+
+  cloudify.gcp.nodes.Route:
+    derived_from: cloudify.nodes.gcp.Route
 
   cloudify.nodes.gcp.FirewallRule:
     derived_from: cloudify.nodes.Root
@@ -541,6 +574,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.firewall.delete
 
+  cloudify.gcp.nodes.FirewallRule:
+    derived_from: cloudify.nodes.gcp.FirewallRule
+
   cloudify.nodes.gcp.SecurityGroup:
     derived_from: cloudify.nodes.SecurityGroup
     properties:
@@ -573,6 +609,9 @@ node_types:
         create:
           implementation: gcp_plugin.cloudify_gcp.compute.security_group.creation_validation
 
+  cloudify.gcp.nodes.SecurityGroup:
+    derived_from: cloudify.nodes.gcp.SecurityGroup
+
   cloudify.nodes.gcp.Access:
     derived_from: cloudify.nodes.Root
     properties:
@@ -584,6 +623,8 @@ node_types:
         description: >
           Interface for rule
 
+  cloudify.gcp.nodes.Access:
+    derived_from: cloudify.nodes.gcp.Access
 
   cloudify.nodes.gcp.KeyPair:
     derived_from: cloudify.nodes.Root
@@ -627,6 +668,9 @@ node_types:
             private_key_path:
               default: { get_property: [SELF, private_key_path] }
 
+  cloudify.gcp.nodes.KeyPair:
+    derived_from: cloudify.nodes.gcp.KeyPair
+
   cloudify.nodes.gcp.ExternalIP:
     derived_from: cloudify.nodes.VirtualIP
     properties:
@@ -640,6 +684,9 @@ node_types:
           is set to true.
         type: string
         default: ''
+
+  cloudify.gcp.nodes.ExternalIP:
+    derived_from: cloudify.nodes.gcp.ExternalIP
 
   cloudify.nodes.gcp.GlobalAddress:
     derived_from: cloudify.nodes.VirtualIP
@@ -668,11 +715,17 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.address.delete
 
+  cloudify.gcp.nodes.GlobalAddress:
+    derived_from: cloudify.nodes.gcp.GlobalAddress
+
   cloudify.nodes.gcp.StaticIP:
-    derived_from: cloudify.gcp.nodes.GlobalAddress
+    derived_from: cloudify.nodes.gcp.GlobalAddress
+
+  cloudify.gcp.nodes.StaticIP:
+    derived_from: cloudify.nodes.gcp.StaticIP
 
   cloudify.nodes.gcp.Address:
-    derived_from: cloudify.gcp.nodes.GlobalAddress
+    derived_from: cloudify.nodes.gcp.GlobalAddress
     properties:
       <<: *client_config
       region:
@@ -691,6 +744,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
             region:
               default: { get_property: [SELF, region]}
+
+  cloudify.gcp.nodes.Address:
+    derived_from: cloudify.nodes.gcp.Address
 
   cloudify.nodes.gcp.Image:
     derived_from: cloudify.nodes.Root
@@ -727,6 +783,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.image.delete
+
+  cloudify.gcp.nodes.Image:
+    derived_from: cloudify.nodes.gcp.Image
 
   cloudify.nodes.gcp.HealthCheck:
     derived_from: cloudify.nodes.Root
@@ -774,6 +833,9 @@ node_types:
             health_check_type:
               default: { get_property: [SELF, health_check_type]}
 
+  cloudify.gcp.nodes.HealthCheck:
+    derived_from: cloudify.nodes.gcp.HealthCheck
+
   cloudify.nodes.gcp.BackendService:
     derived_from: cloudify.nodes.Root
     properties:
@@ -814,6 +876,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.backend_service.delete
+
+  cloudify.gcp.nodes.BackendService:
+    derived_from: cloudify.nodes.gcp.BackendService
 
   cloudify.nodes.gcp.RegionBackendService:
     derived_from: cloudify.nodes.Root
@@ -863,6 +928,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.region_backend_service.delete
 
+  cloudify.gcp.nodes.RegionBackendService:
+    derived_from: cloudify.nodes.gcp.RegionBackendService
+
   cloudify.nodes.gcp.UrlMap:
     derived_from: cloudify.nodes.Root
     properties:
@@ -896,6 +964,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.url_map.delete
+
+  cloudify.gcp.nodes.UrlMap:
+    derived_from: cloudify.nodes.gcp.UrlMap
 
   cloudify.nodes.gcp.TargetProxy:
     derived_from: cloudify.nodes.Root
@@ -953,6 +1024,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.target_proxy.delete
 
+  cloudify.gcp.nodes.TargetProxy:
+    derived_from: cloudify.nodes.gcp.TargetProxy
+
   cloudify.nodes.gcp.SslCertificate:
     derived_from: cloudify.nodes.Root
     properties:
@@ -997,6 +1071,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.ssl_certificate.delete
+
+  cloudify.gcp.nodes.SslCertificate:
+    derived_from: cloudify.nodes.gcp.SslCertificate
 
   cloudify.nodes.gcp.ForwardingRule:
     derived_from: cloudify.nodes.Root
@@ -1093,6 +1170,9 @@ node_types:
         create:
           implementation: gcp_plugin.cloudify_gcp.compute.forwarding_rule.creation_validation
 
+  cloudify.gcp.nodes.ForwardingRule:
+    derived_from: cloudify.nodes.gcp.ForwardingRule
+
   cloudify.nodes.gcp.GlobalForwardingRule:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1149,6 +1229,9 @@ node_types:
         create:
           implementation: gcp_plugin.cloudify_gcp.compute.global_forwarding_rule.creation_validation
 
+  cloudify.gcp.nodes.GlobalForwardingRule:
+    derived_from: cloudify.nodes.gcp.GlobalForwardingRule
+
   cloudify.nodes.gcp.DNSZone:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1183,6 +1266,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.dns.dns.delete
+
+  cloudify.gcp.nodes.DNSZone:
+    derived_from: cloudify.nodes.gcp.DNSZone
 
   cloudify.nodes.gcp.DNSRecord:
     derived_from: cloudify.nodes.Root
@@ -1232,29 +1318,44 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.dns.record.delete
 
+  cloudify.gcp.nodes.DNSRecord:
+    derived_from: cloudify.nodes.gcp.DNSRecord
+
   cloudify.nodes.gcp.DNSAAAARecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: AAAA
 
+  cloudify.gcp.nodes.DNSAAAARecord:
+    derived_from: cloudify.nodes.gcp.DNSAAAARecord
+
   cloudify.nodes.gcp.DNSMXRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: MX
 
+  cloudify.gcp.nodes.DNSMXRecord:
+    derived_from: cloudify.nodes.gcp.DNSMXRecord
+
   cloudify.nodes.gcp.DNSNSRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: NS
 
+  cloudify.gcp.nodes.DNSNSRecord:
+    derived_from: cloudify.nodes.gcp.DNSNSRecord
+
   cloudify.nodes.gcp.DNSTXTRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: TXT
+
+  cloudify.gcp.nodes.DNSTXTRecord:
+    derived_from: cloudify.nodes.gcp.DNSTXTRecord
 
   cloudify.nodes.gcp.KubernetesCluster:
     derived_from: cloudify.nodes.Root
@@ -1286,6 +1387,9 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.container_engine.cluster.stop
         delete:
           implementation: gcp_plugin.cloudify_gcp.container_engine.cluster.delete
+
+  cloudify.gcp.nodes.KubernetesCluster:
+    derived_from: cloudify.nodes.gcp.KubernetesCluster
 
   cloudify.nodes.gcp.KubernetesNodePool:
     derived_from: cloudify.nodes.Root
@@ -1325,6 +1429,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.container_engine.node_pool.delete
 
+  cloudify.gcp.nodes.KubernetesNodePool:
+    derived_from: cloudify.nodes.gcp.KubernetesNodePool
+
   cloudify.nodes.gcp.KubernetesClusterMonitoring:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1362,6 +1469,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.container_engine.monitoring.unset_monitoring_service
 
+  cloudify.gcp.nodes.KubernetesClusterMonitoring:
+    derived_from: cloudify.nodes.gcp.KubernetesClusterMonitoring
+
   cloudify.nodes.gcp.KubernetesClusterlegacyAbac:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1395,6 +1505,9 @@ node_types:
               default: { get_property: [SELF, additional_settings]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.container_engine.legacy_abac.disable_legacy_abac
+
+  cloudify.gcp.nodes.KubernetesClusterlegacyAbac:
+    derived_from: cloudify.nodes.gcp.KubernetesClusterlegacyAbac
 
   cloudify.nodes.gcp.KubernetesClusterNetworkPolicy:
     derived_from: cloudify.nodes.Root
@@ -1438,6 +1551,9 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.container_engine.network_policy.disable_network_policy_addon
 
+  cloudify.gcp.nodes.KubernetesClusterNetworkPolicy:
+    derived_from: cloudify.nodes.gcp.KubernetesClusterNetworkPolicy
+
   cloudify.nodes.gcp.Topic:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1458,6 +1574,9 @@ node_types:
              default: { get_property: [SELF, name]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.pubsub.topic.delete
+
+  cloudify.gcp.nodes.Topic:
+    derived_from: cloudify.nodes.gcp.Topic
 
   cloudify.nodes.gcp.TopicPolicy:
     derived_from: cloudify.nodes.Root
@@ -1487,6 +1606,9 @@ node_types:
            topic:
              default: { get_property: [SELF, topic]}
 
+  cloudify.gcp.nodes.TopicPolicy:
+    derived_from: cloudify.nodes.gcp.TopicPolicy
+
   cloudify.nodes.gcp.TopicMessage:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1512,6 +1634,9 @@ node_types:
              default: { get_property: [SELF, topic]}
            messages:
              default: { get_property: [SELF, messages]}
+
+  cloudify.gcp.nodes.TopicMessage:
+    derived_from: cloudify.nodes.gcp.TopicMessage
 
   cloudify.nodes.gcp.Subscription:
     derived_from: cloudify.nodes.Root
@@ -1562,6 +1687,9 @@ node_types:
         delete:
           implementation:  gcp_plugin.cloudify_gcp.pubsub.subscription.delete
 
+  cloudify.gcp.nodes.Subscription:
+    derived_from: cloudify.nodes.gcp.Subscription
+
   cloudify.nodes.gcp.SubscriptionPolicy:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1590,6 +1718,9 @@ node_types:
            subscription:
              default: { get_property: [SELF, subscription]}
 
+  cloudify.gcp.nodes.SubscriptionPolicy:
+    derived_from: cloudify.nodes.gcp.SubscriptionPolicy
+
   cloudify.nodes.gcp.Acknowledge:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1617,6 +1748,9 @@ node_types:
              default: { get_property: [SELF, subscription]}
            ack_ids:
              default: { get_property: [SELF, ack_ids]}
+
+  cloudify.gcp.nodes.Acknowledge:
+    derived_from: cloudify.nodes.gcp.Acknowledge
 
   cloudify.nodes.gcp.PullRequest:
     derived_from: cloudify.nodes.Root
@@ -1655,6 +1789,9 @@ node_types:
              default: { get_property: [SELF, return_immediately]}
            max_messages:
              default: { get_property: [SELF, max_messages]}
+
+  cloudify.gcp.nodes.PullRequest:
+    derived_from: cloudify.nodes.gcp.PullRequest
 
   cloudify.nodes.gcp.StackDriverGroup:
     derived_from: cloudify.nodes.Root
@@ -1715,6 +1852,9 @@ node_types:
            is_cluster:
              default: { get_property: [SELF, is_cluster]}
 
+  cloudify.gcp.nodes.StackDriverGroup:
+    derived_from: cloudify.nodes.gcp.StackDriverGroup
+
   cloudify.nodes.gcp.StackDriverTimeSeries:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1741,6 +1881,9 @@ node_types:
            time_series:
              default: { get_property: [SELF, time_series]}
 
+  cloudify.gcp.nodes.StackDriverTimeSeries:
+    derived_from: cloudify.nodes.gcp.StackDriverTimeSeries
+
   cloudify.nodes.gcp.StackDriverUpTimeCheckConfig:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1764,6 +1907,9 @@ node_types:
              default: { get_property: [SELF, uptime_check_config]}
         delete:
           implementation: gcp_plugin.cloudify_gcp.monitoring.stackdriver_uptimecheck.delete
+
+  cloudify.gcp.nodes.StackDriverUpTimeCheckConfig:
+    derived_from: cloudify.nodes.gcp.StackDriverUpTimeCheckConfig
 
   cloudify.nodes.gcp.LoggingSink:
     derived_from: cloudify.nodes.Root
@@ -1812,6 +1958,9 @@ node_types:
            sink_type:
              default: { get_property: [SELF, sink_type]}
 
+  cloudify.gcp.nodes.LoggingSink:
+    derived_from: cloudify.nodes.gcp.LoggingSink
+
   cloudify.nodes.gcp.LoggingExclusion:
     derived_from: cloudify.nodes.Root
     properties:
@@ -1859,8 +2008,11 @@ node_types:
            exclusion_type:
              default: { get_property: [SELF, exclusion_type]}
 
+  cloudify.gcp.nodes.LoggingExclusion:
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
+
   cloudify.nodes.gcp.Logging.BillingAccounts.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -1868,14 +2020,20 @@ node_types:
         type: string
         default: BillingAccount
 
+  cloudify.gcp.nodes.Logging.BillingAccounts.sinks:
+    derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.sinks
+
   cloudify.nodes.gcp.Logging.Folders.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
           Sink type, options are ['BillingAccount', 'Folder', 'Organization', 'Project']
         type: string
         default: Folder
+
+  cloudify.gcp.nodes.Logging.Folders.sinks:
+    derived_from: cloudify.nodes.gcp.Logging.Folders.sinks
 
   cloudify.nodes.gcp.Logging.Organizations.sinks:
     derived_from: cloudify.nodes.gcp.LoggingSink
@@ -1886,8 +2044,11 @@ node_types:
         type: string
         default: Organization
 
+  cloudify.gcp.nodes.Logging.Organizations.sinks:
+    derived_from: cloudify.nodes.gcp.Logging.Organizations.sinks
+
   cloudify.nodes.gcp.Logging.Projects.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -1895,8 +2056,11 @@ node_types:
         type: string
         default: Project
 
+  cloudify.gcp.nodes.Logging.Projects.sinks:
+    derived_from: cloudify.nodes.gcp.Logging.Projects.sinks
+
   cloudify.nodes.gcp.Logging.BillingAccounts.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -1904,8 +2068,11 @@ node_types:
         type: string
         default: BillingAccount
 
+  cloudify.gcp.nodes.Logging.BillingAccounts.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.exclusions
+
   cloudify.nodes.gcp.Logging.Folders.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -1913,8 +2080,11 @@ node_types:
         type: string
         default: Folder
 
+  cloudify.gcp.nodes.Logging.Folders.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.Folders.exclusions
+
   cloudify.nodes.gcp.Logging.Organizations.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -1922,18 +2092,27 @@ node_types:
         type: string
         default: Organization
 
+  cloudify.gcp.nodes.Logging.Organizations.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
+
   # Original bug. Keeping until next major version.
   cloudify.nodes.gcp.Logging.Organizatios.exclusions:
-    derived_from: cloudify.gcp.nodes.Logging.Organizations.exclusions
+    derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
+
+  cloudify.gcp.nodes.Logging.Organizatios.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.Organizatios.exclusions
 
   cloudify.nodes.gcp.Logging.Projects.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
           Logging Exclusion type, options are ['BillingAccount', 'Folder', 'Organization', 'Project']
         type: string
         default: Project
+
+  cloudify.gcp.nodes.Logging.Projects.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.Projects.exclusions
 
   cloudify.nodes.gcp.Logging.Projects.metrics:
     derived_from: cloudify.nodes.Root
@@ -1965,6 +2144,9 @@ node_types:
              default: { get_property: [SELF, parent]}
            log_metric:
              default: { get_property: [SELF, log_metric]}
+
+  cloudify.gcp.nodes.Logging.Projects.metrics:
+    derived_from: cloudify.nodes.gcp.Logging.Projects.metrics
 
   cloudify.nodes.gcp.IAM.Role:
     derived_from: cloudify.nodes.Root
@@ -2017,8 +2199,8 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.iam.role.delete
 
-  cloudify.nodes.gcp.Project:
-    derived_from: cloudify.gcp.project
+  cloudify.gcp.nodes.IAM.Role:
+    derived_from: cloudify.nodes.gcp.IAM.Role
 
   cloudify.nodes.gcp.Gcp:
     derived_from: cloudify.nodes.Root
@@ -2051,183 +2233,6 @@ node_types:
               default: { get_property: [ SELF, resource_config ] }
             zones:
               default: { get_property: [ SELF, zones ] }
-
-  cloudify.gcp.nodes.IAM.Role:
-    derived_from: cloudify.nodes.gcp.IAM.Role
-
-  cloudify.gcp.nodes.Instance:
-    derived_from: cloudify.nodes.gcp.Instance
-
-  cloudify.gcp.nodes.InstanceGroup:
-    derived_from: cloudify.nodes.gcp.InstanceGroup
-
-  cloudify.gcp.nodes.Volume:
-    derived_from: cloudify.nodes.gcp.Volume
-
-  cloudify.gcp.nodes.Snapshot:
-      derived_from: cloudify.nodes.gcp.Snapshot
-
-  cloudify.gcp.nodes.Network:
-      derived_from: cloudify.nodes.gcp.Network
-
-  cloudify.gcp.nodes.SubNetwork:
-    derived_from: cloudify.nodes.gcp.SubNetwork
-
-  cloudify.gcp.nodes.VPCNetworkPeering:
-    derived_from: cloudify.nodes.gcp.VPCNetworkPeering
-
-  cloudify.gcp.nodes.Route:
-    derived_from: cloudify.nodes.gcp.Route
-
-  cloudify.gcp.nodes.FirewallRule:
-    derived_from: cloudify.nodes.gcp.FirewallRule
-
-  cloudify.gcp.nodes.SecurityGroup:
-    derived_from: cloudify.nodes.gcp.SecurityGroup
-
-  cloudify.gcp.nodes.Access:
-    derived_from: cloudify.nodes.gcp.Access
-
-  cloudify.gcp.nodes.KeyPair:
-    derived_from: cloudify.nodes.gcp.KeyPair
-
-  cloudify.gcp.nodes.ExternalIP:
-    derived_from: cloudify.nodes.gcp.ExternalIP
-
-  cloudify.gcp.nodes.GlobalAddress:
-    derived_from: cloudify.nodes.gcp.GlobalAddress
-
-  cloudify.gcp.nodes.StaticIP:
-    derived_from: cloudify.nodes.gcp.StaticIP
-
-  cloudify.gcp.nodes.Address:
-    derived_from: cloudify.nodes.gcp.Address
-
-  cloudify.gcp.nodes.Image:
-    derived_from: cloudify.nodes.gcp.Image
-
-  cloudify.gcp.nodes.HealthCheck:
-    derived_from: cloudify.nodes.gcp.HealthCheck
-
-  cloudify.gcp.nodes.BackendService:
-    derived_from: cloudify.nodes.gcp.BackendService
-
-  cloudify.gcp.nodes.RegionBackendService:
-    derived_from: cloudify.nodes.gcp.RegionBackendService
-
-  cloudify.gcp.nodes.UrlMap:
-    derived_from: cloudify.nodes.gcp.UrlMap
-
-  cloudify.gcp.nodes.TargetProxy:
-    derived_from: cloudify.nodes.gcp.TargetProxy
-
-  cloudify.gcp.nodes.SslCertificate:
-    derived_from: cloudify.nodes.gcp.SslCertificate
-
-  cloudify.gcp.nodes.ForwardingRule:
-    derived_from: cloudify.nodes.gcp.ForwardingRule
-
-  cloudify.gcp.nodes.GlobalForwardingRule:
-    derived_from: cloudify.nodes.gcp.GlobalForwardingRule
-
-  cloudify.gcp.nodes.DNSZone:
-    derived_from: cloudify.nodes.gcp.DNSZone
-
-  cloudify.gcp.nodes.DNSRecord:
-    derived_from: cloudify.nodes.gcp.DNSRecord
-
-  cloudify.gcp.nodes.DNSAAAARecord:
-    derived_from: cloudify.nodes.gcp.DNSAAAARecord
-
-  cloudify.gcp.nodes.DNSMXRecord:
-    derived_from: cloudify.nodes.gcp.DNSMXRecord
-
-  cloudify.gcp.nodes.DNSNSRecord:
-    derived_from: cloudify.nodes.gcp.DNSNSRecord
-
-  cloudify.gcp.nodes.DNSTXTRecord:
-    derived_from: cloudify.nodes.gcp.DNSTXTRecord
-
-  cloudify.gcp.nodes.KubernetesCluster:
-    derived_from: cloudify.nodes.gcp.KubernetesCluster
-
-  cloudify.gcp.nodes.KubernetesNodePool:
-    derived_from: cloudify.nodes.gcp.KubernetesNodePool
-
-  cloudify.gcp.nodes.KubernetesClusterMonitoring:
-    derived_from: cloudify.nodes.gcp.KubernetesClusterMonitoring
-
-  cloudify.gcp.nodes.KubernetesClusterlegacyAbac:
-    derived_from: cloudify.nodes.gcp.KubernetesClusterlegacyAbac
-
-  cloudify.gcp.nodes.KubernetesClusterNetworkPolicy:
-    derived_from: cloudify.nodes.gcp.KubernetesClusterNetworkPolicy
-
-  cloudify.gcp.nodes.Topic:
-    derived_from: cloudify.nodes.gcp.Topic
-
-  cloudify.gcp.nodes.TopicPolicy:
-    derived_from: cloudify.nodes.gcp.TopicPolicy
-
-  cloudify.gcp.nodes.TopicMessage:
-    derived_from: cloudify.nodes.gcp.TopicMessage
-
-  cloudify.gcp.nodes.Subscription:
-    derived_from: cloudify.nodes.gcp.Subscription
-
-  cloudify.gcp.nodes.SubscriptionPolicy:
-    derived_from: cloudify.nodes.gcp.SubscriptionPolicy
-
-  cloudify.gcp.nodes.Acknowledge:
-    derived_from: cloudify.nodes.gcp.Acknowledge
-
-  cloudify.gcp.nodes.PullRequest:
-    derived_from: cloudify.nodes.gcp.PullRequest
-
-  cloudify.gcp.StackDriverGroup:
-    derived_from: cloudify.nodes.gcp.StackDriverGroup
-
-  cloudify.gcp.nodes.StackDriverTimeSeries:
-    derived_from: cloudify.nodes.gcp.StackDriverTimeSeries
-
-  cloudify.gcp.nodes.StackDriverUpTimeCheckConfig:
-    derived_from: cloudify.nodes.gcp.StackDriverUpTimeCheckConfig
-
-  cloudify.gcp.nodes.LoggingSink:
-    derived_from: cloudify.nodes.gcp.LoggingSink
-
-  cloudify.gcp.nodes.LoggingExclusion:
-    derived_from: cloudify.nodes.gcp.LoggingExclusion
-
-  cloudify.gcp.nodes.Logging.BillingAccounts.sinks:
-    derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.sinks
-
-  cloudify.gcp.nodes.Logging.Folders.sinks:
-    derived_from: cloudify.nodes.gcp.Logging.Folders.sinks
-
-  cloudify.gcp.Logging.Organizations.sinks:
-    derived_from: cloudify.nodes.gcp.Logging.Organizations.sinks
-
-  cloudify.gcp.nodes.Logging.Projects.sinks:
-    derived_from: cloudify.nodes.gcp.Logging.Projects.sinks
-
-  cloudify.gcp.nodes.Logging.BillingAccounts.exclusions:
-    derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.exclusions
-
-  cloudify.gcp.nodes.Logging.Folders.exclusions:
-    derived_from: cloudify.nodes.gcp.Logging.Folders.exclusions
-
-  cloudify.gcp.nodes.Logging.Organizations.exclusions:
-    derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
-
-  cloudify.gcp.nodes.Logging.Organizatios.exclusions:
-    derived_from: cloudify.nodes.gcp.Logging.Organizatios.exclusions
-
-  cloudify.gcp.nodes.Logging.Projects.exclusions:
-    derived_from: cloudify.nodes.gcp.Logging.Projects.exclusions
-
-  cloudify.gcp.nodes.Logging.Projects.metrics:
-    derived_from: cloudify.nodes.gcp.Logging.Projects.metrics
 
   cloudify.gcp.nodes.Gcp:
     derived_from: cloudify.nodes.gcp.Gcp
@@ -2318,7 +2323,6 @@ relationships:
             disk_name:
               default: { get_attribute: [SOURCE, name] }
 
-
   cloudify.gcp.relationships.instance_connected_to_disk:
     derived_from: cloudify.relationships.gcp.instance_connected_to_disk
 
@@ -2342,7 +2346,7 @@ relationships:
               default: { get_attribute: [SOURCE, selfLink] }
 
   cloudify.gcp.relationships.instance_connected_to_instance_group:
-      derived_from: cloudify.relationships.gcp.instance_connected_to_instance_group
+    derived_from: cloudify.relationships.gcp.instance_connected_to_instance_group
 
   cloudify.relationships.gcp.uses_as_backend:
     derived_from: cloudify.relationships.connected_to
@@ -2364,7 +2368,7 @@ relationships:
               default: { get_attribute: [TARGET, selfLink] }
 
   cloudify.gcp.relationships.uses_as_backend:
-      derived_from: cloudify.relationships.gcp.uses_as_backend
+    derived_from: cloudify.relationships.gcp.uses_as_backend
 
   cloudify.relationships.gcp.uses_as_region_backend:
     derived_from: cloudify.relationships.connected_to
@@ -2412,7 +2416,7 @@ relationships:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.dns_record_connected_to_instance:
-      derived_from: cloudify.relationships.gcp.dns_record_connected_to_instance
+    derived_from: cloudify.relationships.gcp.dns_record_connected_to_instance
 
   cloudify.relationships.gcp.dns_record_connected_to_ip:
     derived_from: cloudify.relationships.connected_to

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -3,7 +3,7 @@ plugins:
   gcp_plugin:
     executor: central_deployment_agent
     package_name: cloudify-gcp-plugin
-    package_version: '1.8.6'
+    package_version: '1.8.7'
 
 dsl_definitions:
   use_external_resource_desc: &use_external_resource_desc >
@@ -67,6 +67,9 @@ node_types:
   cloudify.gcp.project:
     derived_from: cloudify.nodes.gcp.project
 
+  cloudify.gcp.nodes.project:
+    derived_from: cloudify.nodes.gcp.project
+
   cloudify.nodes.gcp.PolicyBinding:
     derived_from: cloudify.nodes.Root
     properties:
@@ -98,6 +101,9 @@ node_types:
               default: { get_property: [SELF, resource]}
             policy:
               default: { get_property: [SELF, policy]}
+
+  cloudify.gcp.nodes.PolicyBinding:
+    derived_from: cloudify.nodes.gcp.PolicyBinding
 
   cloudify.nodes.gcp.Instance:
     derived_from: cloudify.nodes.Compute
@@ -713,13 +719,13 @@ node_types:
     derived_from: cloudify.nodes.gcp.GlobalAddress
 
   cloudify.nodes.gcp.StaticIP:
-    derived_from: cloudify.gcp.nodes.GlobalAddress
+    derived_from: cloudify.nodes.gcp.GlobalAddress
 
   cloudify.gcp.nodes.StaticIP:
     derived_from: cloudify.nodes.gcp.StaticIP
 
   cloudify.nodes.gcp.Address:
-    derived_from: cloudify.gcp.nodes.GlobalAddress
+    derived_from: cloudify.nodes.gcp.GlobalAddress
     properties:
       <<: *client_config
       region:
@@ -923,7 +929,7 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.compute.region_backend_service.delete
 
   cloudify.gcp.nodes.RegionBackendService:
-    derived_from: cloudify.nodes.gcp.RegionBackendServic
+    derived_from: cloudify.nodes.gcp.RegionBackendService
 
   cloudify.nodes.gcp.UrlMap:
     derived_from: cloudify.nodes.Root
@@ -1316,7 +1322,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSRecord
 
   cloudify.nodes.gcp.DNSAAAARecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: AAAA
@@ -1325,7 +1331,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSAAAARecord
 
   cloudify.nodes.gcp.DNSMXRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: MX
@@ -1334,7 +1340,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSMXRecord
 
   cloudify.nodes.gcp.DNSNSRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: NS
@@ -1343,7 +1349,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSNSRecord
 
   cloudify.nodes.gcp.DNSTXTRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: TXT
@@ -1876,7 +1882,7 @@ node_types:
              default: { get_property: [SELF, time_series]}
 
   cloudify.gcp.nodes.StackDriverTimeSeries:
-    derived_from: loudify.nodes.gcp.StackDriverTimeSeries
+    derived_from: cloudify.nodes.gcp.StackDriverTimeSeries
 
   cloudify.nodes.gcp.StackDriverUpTimeCheckConfig:
     derived_from: cloudify.nodes.Root
@@ -2006,7 +2012,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.LoggingExclusion
 
   cloudify.nodes.gcp.Logging.BillingAccounts.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2018,7 +2024,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.sinks
 
   cloudify.nodes.gcp.Logging.Folders.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2030,7 +2036,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Folders.sinks
 
   cloudify.nodes.gcp.Logging.Organizations.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2042,7 +2048,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Organizations.sinks
 
   cloudify.nodes.gcp.Logging.Projects.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2054,7 +2060,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Projects.sinks
 
   cloudify.nodes.gcp.Logging.BillingAccounts.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2066,7 +2072,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.exclusions
 
   cloudify.nodes.gcp.Logging.Folders.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2078,7 +2084,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Folders.exclusions
 
   cloudify.nodes.gcp.Logging.Organizations.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2090,11 +2096,14 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
 
   # Original bug. Keeping until next major version.
+  cloudify.nodes.gcp.Logging.Organizatios.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
+
   cloudify.gcp.nodes.Logging.Organizatios.exclusions:
-    derived_from: cloudify.gcp.nodes.Logging.Organizations.exclusions
+    derived_from: cloudify.nodes.gcp.Logging.Organizatios.exclusions
 
   cloudify.nodes.gcp.Logging.Projects.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2190,9 +2199,6 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.iam.role.delete
 
-  cloudify.nodes.gcp.Project:
-    derived_from: cloudify.gcp.project
-
   cloudify.gcp.nodes.IAM.Role:
     derived_from: cloudify.nodes.gcp.IAM.Role
 
@@ -2228,9 +2234,12 @@ node_types:
             zones:
               default: { get_property: [ SELF, zones ] }
 
+  cloudify.gcp.nodes.Gcp:
+    derived_from: cloudify.nodes.gcp.Gcp
+
 relationships:
 
-  cloudify.gcp.relationships.instance_connected_to_security_group:
+  cloudify.relationships.gcp.instance_connected_to_security_group:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2253,7 +2262,10 @@ relationships:
             tag:
               default: [{ get_attribute: [TARGET, name] }]
 
-  cloudify.gcp.relationships.instance_connected_to_ip:
+  cloudify.gcp.relationships.instance_connected_to_security_group:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_security_group
+
+  cloudify.relationships.gcp.instance_connected_to_ip:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2272,7 +2284,10 @@ relationships:
             zone:
               default: { get_attribute: [SOURCE, zone] }
 
-  cloudify.gcp.relationships.instance_connected_to_keypair:
+  cloudify.gcp.relationships.instance_connected_to_ip:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_ip
+
+  cloudify.relationships.gcp.instance_connected_to_keypair:
     derived_from: cloudify.relationships.connected_to
     target_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2282,7 +2297,10 @@ relationships:
             instance_name:
               default: { get_attribute: [SOURCE, name] }
 
-  cloudify.gcp.relationships.instance_connected_to_disk:
+  cloudify.gcp.relationships.instance_connected_to_keypair:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_keypair
+
+  cloudify.relationships.gcp.instance_connected_to_disk:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2305,7 +2323,10 @@ relationships:
             disk_name:
               default: { get_attribute: [SOURCE, name] }
 
-  cloudify.gcp.relationships.instance_connected_to_instance_group:
+  cloudify.gcp.relationships.instance_connected_to_disk:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_disk
+
+  cloudify.relationships.gcp.instance_connected_to_instance_group:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2324,7 +2345,10 @@ relationships:
             instance_url:
               default: { get_attribute: [SOURCE, selfLink] }
 
-  cloudify.gcp.relationships.uses_as_backend:
+  cloudify.gcp.relationships.instance_connected_to_instance_group:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_instance_group
+
+  cloudify.relationships.gcp.uses_as_backend:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2343,7 +2367,10 @@ relationships:
             group_self_url:
               default: { get_attribute: [TARGET, selfLink] }
 
-  cloudify.gcp.relationships.uses_as_region_backend:
+  cloudify.gcp.relationships.uses_as_backend:
+    derived_from: cloudify.relationships.gcp.uses_as_backend
+
+  cloudify.relationships.gcp.uses_as_region_backend:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2362,46 +2389,76 @@ relationships:
             group_self_url:
               default: { get_attribute: [TARGET, selfLink] }
 
-  cloudify.gcp.relationships.contained_in_compute:
+  cloudify.gcp.relationships.uses_as_region_backend:
+    derived_from: cloudify.relationships.gcp.uses_as_region_backend
+
+  cloudify.relationships.gcp.contained_in_compute:
     derived_from: cloudify.relationships.contained_in
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
         preconfigure:
           implementation: gcp_plugin.cloudify_gcp.compute.instance.contained_in
 
-  cloudify.gcp.relationships.dns_record_contained_in_zone:
+  cloudify.gcp.relationships.contained_in_compute:
+    derived_from: cloudify.relationships.gcp.contained_in_compute
+
+  cloudify.relationships.gcp.dns_record_contained_in_zone:
     derived_from: cloudify.relationships.contained_in
     source_interfaces:
       cloudify.interfaces.validation:
         create:
           implementation: gcp_plugin.cloudify_gcp.dns.record.validate_contained_in
 
+  cloudify.gcp.relationships.dns_record_contained_in_zone:
+    derived_from: cloudify.relationships.gcp.dns_record_contained_in_zone
+
+  cloudify.relationships.gcp.dns_record_connected_to_instance:
+    derived_from: cloudify.relationships.connected_to
+
   cloudify.gcp.relationships.dns_record_connected_to_instance:
+    derived_from: cloudify.relationships.gcp.dns_record_connected_to_instance
+
+  cloudify.relationships.gcp.dns_record_connected_to_ip:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.dns_record_connected_to_ip:
-    derived_from: cloudify.relationships.connected_to
+    derived_from: cloudify.relationships.gcp.dns_record_connected_to_ip
 
-  cloudify.gcp.relationships.contained_in_network:
+  cloudify.relationships.gcp.contained_in_network:
     derived_from: cloudify.relationships.contained_in
 
-  cloudify.gcp.relationships.instance_contained_in_network:
+  cloudify.gcp.relationships.contained_in_network:
+    derived_from: cloudify.relationships.gcp.contained_in_network
+
+  cloudify.relationships.gcp.instance_contained_in_network:
     derived_from: cloudify.relationships.contained_in
     source_interfaces:
       cloudify.interfaces.validation:
         create:
           implementation: gcp_plugin.cloudify_gcp.compute.instance.validate_contained_in_network
 
+  cloudify.gcp.relationships.instance_contained_in_network:
+    derived_from: cloudify.relationships.gcp.instance_contained_in_network
+
+  cloudify.relationships.gcp.forwarding_rule_connected_to_target_proxy:
+    derived_from: cloudify.relationships.connected_to
+
   cloudify.gcp.relationships.forwarding_rule_connected_to_target_proxy:
+    derived_from: cloudify.relationships.gcp.forwarding_rule_connected_to_target_proxy
+
+  cloudify.relationships.gcp.vpn_network_peering_connected_to_network:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.vpn_network_peering_connected_to_network:
+    derived_from: cloudify.relationships.gcp.vpn_network_peering_connected_to_network
+
+  cloudify.relationships.gcp.subscription_connected_to_topic:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.subscription_connected_to_topic:
-    derived_from: cloudify.relationships.connected_to
+    derived_from: cloudify.relationships.gcp.subscription_connected_to_topic
 
-  cloudify.gcp.relationships.instance_remove_access_config:
+  cloudify.relationships.gcp.instance_remove_access_config:
     derived_from: cloudify.relationships.depends_on
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2416,6 +2473,9 @@ relationships:
               default: { get_property: [SOURCE, name] }
             interface:
               default: { get_property: [SOURCE, interface] }
+
+  cloudify.gcp.relationships.instance_remove_access_config:
+    derived_from: cloudify.relationships.gcp.instance_remove_access_config
 
 workflows:
 

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -3,7 +3,7 @@ plugins:
   gcp_plugin:
     executor: central_deployment_agent
     package_name: cloudify-gcp-plugin
-    package_version: '1.8.6'
+    package_version: '1.8.7'
 
 dsl_definitions:
   use_external_resource_desc: &use_external_resource_desc >
@@ -41,7 +41,7 @@ dsl_definitions:
 
 node_types:
 
-  cloudify.gcp.project:
+  cloudify.nodes.gcp.project:
     derived_from: cloudify.nodes.Root
     properties:
       <<: *external_resource
@@ -63,6 +63,12 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.admin.projects.create
         delete:
           implementation: gcp_plugin.cloudify_gcp.admin.projects.delete
+
+  cloudify.gcp.project:
+    derived_from: cloudify.nodes.gcp.project
+
+  cloudify.gcp.nodes.project:
+    derived_from: cloudify.nodes.gcp.project
 
   cloudify.nodes.gcp.PolicyBinding:
     derived_from: cloudify.nodes.Root
@@ -95,6 +101,9 @@ node_types:
               default: { get_property: [SELF, resource]}
             policy:
               default: { get_property: [SELF, policy]}
+
+  cloudify.gcp.nodes.PolicyBinding:
+    derived_from: cloudify.nodes.gcp.PolicyBinding
 
   cloudify.nodes.gcp.Instance:
     derived_from: cloudify.nodes.Compute
@@ -221,7 +230,6 @@ node_types:
   cloudify.gcp.nodes.Instance:
     derived_from: cloudify.nodes.gcp.Instance
 
-
   cloudify.nodes.gcp.InstanceGroup:
     derived_from: cloudify.nodes.Root
     properties:
@@ -258,8 +266,6 @@ node_types:
 
   cloudify.gcp.nodes.InstanceGroup:
     derived_from: cloudify.nodes.gcp.InstanceGroup
-
-
 
   cloudify.nodes.gcp.Volume:
     derived_from: cloudify.nodes.Volume
@@ -309,7 +315,7 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.compute.disk.delete
 
   cloudify.gcp.nodes.Volume:
-      derived_from: cloudify.nodes.gcp.Volume
+    derived_from: cloudify.nodes.gcp.Volume
 
   cloudify.nodes.gcp.Snapshot:
     derived_from: cloudify.nodes.Root
@@ -372,7 +378,7 @@ node_types:
               default: { get_property: [SELF, name] }
 
   cloudify.gcp.nodes.Network:
-      derived_from: cloudify.nodes.gcp.Network
+    derived_from: cloudify.nodes.gcp.Network
 
   cloudify.nodes.gcp.SubNetwork:
     derived_from: cloudify.nodes.Subnet
@@ -458,7 +464,7 @@ node_types:
               default: { get_property: [SELF, peerNetwork] }
 
   cloudify.gcp.nodes.VPCNetworkPeering:
-      derived_from: cloudify.nodes.gcp.VPCNetworkPeering
+    derived_from: cloudify.nodes.gcp.VPCNetworkPeering
 
   cloudify.nodes.gcp.Route:
     derived_from: cloudify.nodes.Router
@@ -513,7 +519,7 @@ node_types:
               default: { get_attribute: [SELF, name] }
 
   cloudify.gcp.nodes.Route:
-      derived_from: cloudify.nodes.gcp.Route
+    derived_from: cloudify.nodes.gcp.Route
 
   cloudify.nodes.gcp.FirewallRule:
     derived_from: cloudify.nodes.Root
@@ -618,8 +624,7 @@ node_types:
           Interface for rule
 
   cloudify.gcp.nodes.Access:
-      derived_from: cloudify.nodes.gcp.Access
-
+    derived_from: cloudify.nodes.gcp.Access
 
   cloudify.nodes.gcp.KeyPair:
     derived_from: cloudify.nodes.Root
@@ -710,11 +715,17 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.compute.address.delete
 
-  cloudify.gcp.nodes.StaticIP:
+  cloudify.gcp.nodes.GlobalAddress:
     derived_from: cloudify.nodes.gcp.GlobalAddress
 
+  cloudify.nodes.gcp.StaticIP:
+    derived_from: cloudify.nodes.gcp.GlobalAddress
+
+  cloudify.gcp.nodes.StaticIP:
+    derived_from: cloudify.nodes.gcp.StaticIP
+
   cloudify.nodes.gcp.Address:
-    derived_from: cloudify.gcp.nodes.GlobalAddress
+    derived_from: cloudify.nodes.gcp.GlobalAddress
     properties:
       <<: *client_config
       region:
@@ -955,7 +966,7 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.compute.url_map.delete
 
   cloudify.gcp.nodes.UrlMap:
-      derived_from: cloudify.nodes.gcp.UrlMap
+    derived_from: cloudify.nodes.gcp.UrlMap
 
   cloudify.nodes.gcp.TargetProxy:
     derived_from: cloudify.nodes.Root
@@ -1308,10 +1319,10 @@ node_types:
           implementation: gcp_plugin.cloudify_gcp.dns.record.delete
 
   cloudify.gcp.nodes.DNSRecord:
-      derived_from: cloudify.nodes.gcp.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
 
   cloudify.nodes.gcp.DNSAAAARecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: AAAA
@@ -1320,7 +1331,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSAAAARecord
 
   cloudify.nodes.gcp.DNSMXRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: MX
@@ -1329,7 +1340,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSMXRecord
 
   cloudify.nodes.gcp.DNSNSRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: NS
@@ -1338,7 +1349,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.DNSNSRecord
 
   cloudify.nodes.gcp.DNSTXTRecord:
-    derived_from: cloudify.gcp.nodes.DNSRecord
+    derived_from: cloudify.nodes.gcp.DNSRecord
     properties:
       type:
         default: TXT
@@ -1379,7 +1390,7 @@ node_types:
 
   cloudify.gcp.nodes.KubernetesCluster:
     derived_from: cloudify.nodes.gcp.KubernetesCluster
-   
+
   cloudify.nodes.gcp.KubernetesNodePool:
     derived_from: cloudify.nodes.Root
     properties:
@@ -2001,7 +2012,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.LoggingExclusion
 
   cloudify.nodes.gcp.Logging.BillingAccounts.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2013,7 +2024,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.sinks
 
   cloudify.nodes.gcp.Logging.Folders.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2025,7 +2036,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Folders.sinks
 
   cloudify.nodes.gcp.Logging.Organizations.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2037,7 +2048,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Organizations.sinks
 
   cloudify.nodes.gcp.Logging.Projects.sinks:
-    derived_from: cloudify.gcp.nodes.LoggingSink
+    derived_from: cloudify.nodes.gcp.LoggingSink
     properties:
       sink_type:
         description: >
@@ -2049,7 +2060,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Projects.sinks
 
   cloudify.nodes.gcp.Logging.BillingAccounts.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2061,7 +2072,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.BillingAccounts.exclusions
 
   cloudify.nodes.gcp.Logging.Folders.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2073,7 +2084,7 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Folders.exclusions
 
   cloudify.nodes.gcp.Logging.Organizations.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2085,14 +2096,14 @@ node_types:
     derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
 
   # Original bug. Keeping until next major version.
-  cloudify.gcp.nodes.Logging.Organizatios.exclusions:
-    derived_from: cloudify.gcp.nodes.Logging.Organizations.exclusions
-
   cloudify.nodes.gcp.Logging.Organizatios.exclusions:
-    derived_from: cloudify.gcp.nodes.Logging.Organizatios.exclusions
+    derived_from: cloudify.nodes.gcp.Logging.Organizations.exclusions
+
+  cloudify.gcp.nodes.Logging.Organizatios.exclusions:
+    derived_from: cloudify.nodes.gcp.Logging.Organizatios.exclusions
 
   cloudify.nodes.gcp.Logging.Projects.exclusions:
-    derived_from: cloudify.gcp.nodes.LoggingExclusion
+    derived_from: cloudify.nodes.gcp.LoggingExclusion
     properties:
       exclusion_type:
         description: >
@@ -2135,7 +2146,7 @@ node_types:
              default: { get_property: [SELF, log_metric]}
 
   cloudify.gcp.nodes.Logging.Projects.metrics:
-      derived_from: cloudify.nodes.gcp.Logging.Projects.metrics
+    derived_from: cloudify.nodes.gcp.Logging.Projects.metrics
 
   cloudify.nodes.gcp.IAM.Role:
     derived_from: cloudify.nodes.Root
@@ -2188,9 +2199,6 @@ node_types:
         delete:
           implementation: gcp_plugin.cloudify_gcp.iam.role.delete
 
-  cloudify.nodes.gcp.Project:
-    derived_from: cloudify.gcp.project
-
   cloudify.gcp.nodes.IAM.Role:
     derived_from: cloudify.nodes.gcp.IAM.Role
 
@@ -2226,9 +2234,12 @@ node_types:
             zones:
               default: { get_property: [ SELF, zones ] }
 
+  cloudify.gcp.nodes.Gcp:
+    derived_from: cloudify.nodes.gcp.Gcp
+
 relationships:
 
-  cloudify.gcp.relationships.instance_connected_to_security_group:
+  cloudify.relationships.gcp.instance_connected_to_security_group:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2251,7 +2262,10 @@ relationships:
             tag:
               default: [{ get_attribute: [TARGET, name] }]
 
-  cloudify.gcp.relationships.instance_connected_to_ip:
+  cloudify.gcp.relationships.instance_connected_to_security_group:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_security_group
+
+  cloudify.relationships.gcp.instance_connected_to_ip:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2270,7 +2284,10 @@ relationships:
             zone:
               default: { get_attribute: [SOURCE, zone] }
 
-  cloudify.gcp.relationships.instance_connected_to_keypair:
+  cloudify.gcp.relationships.instance_connected_to_ip:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_ip
+
+  cloudify.relationships.gcp.instance_connected_to_keypair:
     derived_from: cloudify.relationships.connected_to
     target_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2280,7 +2297,10 @@ relationships:
             instance_name:
               default: { get_attribute: [SOURCE, name] }
 
-  cloudify.gcp.relationships.instance_connected_to_disk:
+  cloudify.gcp.relationships.instance_connected_to_keypair:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_keypair
+
+  cloudify.relationships.gcp.instance_connected_to_disk:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2303,7 +2323,10 @@ relationships:
             disk_name:
               default: { get_attribute: [SOURCE, name] }
 
-  cloudify.gcp.relationships.instance_connected_to_instance_group:
+  cloudify.gcp.relationships.instance_connected_to_disk:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_disk
+
+  cloudify.relationships.gcp.instance_connected_to_instance_group:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2322,7 +2345,10 @@ relationships:
             instance_url:
               default: { get_attribute: [SOURCE, selfLink] }
 
-  cloudify.gcp.relationships.uses_as_backend:
+  cloudify.gcp.relationships.instance_connected_to_instance_group:
+    derived_from: cloudify.relationships.gcp.instance_connected_to_instance_group
+
+  cloudify.relationships.gcp.uses_as_backend:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2341,7 +2367,10 @@ relationships:
             group_self_url:
               default: { get_attribute: [TARGET, selfLink] }
 
-  cloudify.gcp.relationships.uses_as_region_backend:
+  cloudify.gcp.relationships.uses_as_backend:
+    derived_from: cloudify.relationships.gcp.uses_as_backend
+
+  cloudify.relationships.gcp.uses_as_region_backend:
     derived_from: cloudify.relationships.connected_to
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2360,46 +2389,76 @@ relationships:
             group_self_url:
               default: { get_attribute: [TARGET, selfLink] }
 
-  cloudify.gcp.relationships.contained_in_compute:
+  cloudify.gcp.relationships.uses_as_region_backend:
+    derived_from: cloudify.relationships.gcp.uses_as_region_backend
+
+  cloudify.relationships.gcp.contained_in_compute:
     derived_from: cloudify.relationships.contained_in
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
         preconfigure:
           implementation: gcp_plugin.cloudify_gcp.compute.instance.contained_in
 
-  cloudify.gcp.relationships.dns_record_contained_in_zone:
+  cloudify.gcp.relationships.contained_in_compute:
+    derived_from: cloudify.relationships.gcp.contained_in_compute
+
+  cloudify.relationships.gcp.dns_record_contained_in_zone:
     derived_from: cloudify.relationships.contained_in
     source_interfaces:
       cloudify.interfaces.validation:
         create:
           implementation: gcp_plugin.cloudify_gcp.dns.record.validate_contained_in
 
+  cloudify.gcp.relationships.dns_record_contained_in_zone:
+    derived_from: cloudify.relationships.gcp.dns_record_contained_in_zone
+
+  cloudify.relationships.gcp.dns_record_connected_to_instance:
+    derived_from: cloudify.relationships.connected_to
+
   cloudify.gcp.relationships.dns_record_connected_to_instance:
+    derived_from: cloudify.relationships.gcp.dns_record_connected_to_instance
+
+  cloudify.relationships.gcp.dns_record_connected_to_ip:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.dns_record_connected_to_ip:
-    derived_from: cloudify.relationships.connected_to
+    derived_from: cloudify.relationships.gcp.dns_record_connected_to_ip
 
-  cloudify.gcp.relationships.contained_in_network:
+  cloudify.relationships.gcp.contained_in_network:
     derived_from: cloudify.relationships.contained_in
 
-  cloudify.gcp.relationships.instance_contained_in_network:
+  cloudify.gcp.relationships.contained_in_network:
+    derived_from: cloudify.relationships.gcp.contained_in_network
+
+  cloudify.relationships.gcp.instance_contained_in_network:
     derived_from: cloudify.relationships.contained_in
     source_interfaces:
       cloudify.interfaces.validation:
         create:
           implementation: gcp_plugin.cloudify_gcp.compute.instance.validate_contained_in_network
 
+  cloudify.gcp.relationships.instance_contained_in_network:
+    derived_from: cloudify.relationships.gcp.instance_contained_in_network
+
+  cloudify.relationships.gcp.forwarding_rule_connected_to_target_proxy:
+    derived_from: cloudify.relationships.connected_to
+
   cloudify.gcp.relationships.forwarding_rule_connected_to_target_proxy:
+    derived_from: cloudify.relationships.gcp.forwarding_rule_connected_to_target_proxy
+
+  cloudify.relationships.gcp.vpn_network_peering_connected_to_network:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.vpn_network_peering_connected_to_network:
+    derived_from: cloudify.relationships.gcp.vpn_network_peering_connected_to_network
+
+  cloudify.relationships.gcp.subscription_connected_to_topic:
     derived_from: cloudify.relationships.connected_to
 
   cloudify.gcp.relationships.subscription_connected_to_topic:
-    derived_from: cloudify.relationships.connected_to
+    derived_from: cloudify.relationships.gcp.subscription_connected_to_topic
 
-  cloudify.gcp.relationships.instance_remove_access_config:
+  cloudify.relationships.gcp.instance_remove_access_config:
     derived_from: cloudify.relationships.depends_on
     source_interfaces:
       cloudify.interfaces.relationship_lifecycle:
@@ -2414,6 +2473,9 @@ relationships:
               default: { get_property: [SOURCE, name] }
             interface:
               default: { get_property: [SOURCE, interface] }
+
+  cloudify.gcp.relationships.instance_remove_access_config:
+    derived_from: cloudify.relationships.gcp.instance_remove_access_config
 
 workflows:
 


### PR DESCRIPTION
gone through the types again , there were a couple of issues in plugin_1_4.yaml and v2_plugin.yaml , worked on making the new type format the primary derived_from , so later when we remove the old types permanently, we don't need to change again