### PR TITLE
add remote manager & unique id to tests (#214)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,9 @@ jobs:
     
     steps:
       - checkout
-      - managerorb/create_manager_container_latest
+      - attach_workspace:
+          at: workspace
+      - setup_manager
       - prepare_test_manager
       - run_virtual_machine_test
 
@@ -152,7 +154,9 @@ jobs:
       CLOUDIFY_SSL_TRUST_ALL: true
     steps:
       - checkout
-      - managerorb/create_manager_container_latest
+      - attach_workspace:
+          at: workspace
+      - setup_manager
       - prepare_test_manager
       - run_gke_test
 
@@ -162,7 +166,9 @@ jobs:
       CLOUDIFY_SSL_TRUST_ALL: true
     steps:
       - checkout
-      - managerorb/create_manager_container_latest
+      - attach_workspace:
+          at: workspace
+      - setup_manager
       - prepare_test_manager
       - run_attach_disk_test
       - run_container_engine_test
@@ -173,7 +179,9 @@ jobs:
       CLOUDIFY_SSL_TRUST_ALL: true
     steps:
       - checkout
-      - managerorb/create_manager_container_latest
+      - attach_workspace:
+          at: workspace
+      - setup_manager
       - prepare_test_manager
       - run_http_balancer_test
       - run_https_balancer_test
@@ -184,7 +192,9 @@ jobs:
       CLOUDIFY_SSL_TRUST_ALL: true
     steps:
       - checkout
-      - managerorb/create_manager_container_latest
+      - attach_workspace:
+          at: workspace
+      - setup_manager
       - prepare_test_manager
       - run_ssl_balancer_test
       - run_tcp_balancer_test
@@ -195,7 +205,9 @@ jobs:
       CLOUDIFY_SSL_TRUST_ALL: true
     steps:
       - checkout
-      - managerorb/create_manager_container_latest
+      - attach_workspace:
+          at: workspace
+      - setup_manager
       - prepare_test_manager
       - run_gcp_example_network_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,23 +35,50 @@ executors:
        image: ubuntu-2004:202201-02
 
 commands:
+
+  setup_manager:
+    steps:
+      - run: |
+          if [[ -z "${CLOUDIFY_HOST}" ]]; then
+              exit 1
+          fi
+      - run: |
+          if [[ -z "${CLOUDIFY_TENANT}" ]]; then
+              exit 1
+          fi
+      - run: |
+          if [[ -z "${CLOUDIFY_TOKEN}" ]]; then
+              exit 1
+          fi
+      - run: |
+          response=$(curl --write-out '%{http_code}' --silent --insecure --header "Tenant: ${CLOUDIFY_TENANT}" --header "Authentication-Token: ${CLOUDIFY_TOKEN}" https://$CLOUDIFY_HOST/api/v3.1/status --output /dev/null)
+          if [[ $response != 200 ]]; then
+              echo "Failed to get manager status";
+              exit 1
+          fi
+      - run: pip3 install https://github.com/cloudify-incubator/cloudify-ecosystem-test/archive/refs/heads/master.zip
+      - run: git submodule update --init --recursive --remote
+
   prepare_test_manager:
     steps:
-      - run: ecosystem-test prepare-test-manager -l $TEST_LICENSE -es gcp_credentials=$gcp_credentials -s region=us-east1 -s zone=us-east1-b -es ssl_cert=$ssl_cert -es ssl_key=$ssl_key --yum-package python-netaddr --yum-package git  -p $(find ~/project/workspace/build/ -name *manylinux-py311-none-linux_x86_64.wgn*)  ~/project/plugin_1_4.yaml
-      - run: ecosystem-test upload-plugin -PN utilities
-      - run: ecosystem-test upload-plugin -PN ansible
-      - run: ecosystem-test upload-plugin -PN kubernetes
+      - run: ecosystem-test prepare-remote-test-manager -es gcp_credentials=$gcp_credentials -s region=us-east1 -s zone=us-east1-b -es ssl_cert=$ssl_cert -es ssl_key=$ssl_key -p $(find ~/project/workspace/build/ -name *manylinux-py311-none-linux_x86_64.wgn*)  ~/project/plugin_1_4.yaml
+      - run: ecosystem-test remote-upload-plugin -PN utilities
+      - run: ecosystem-test remote-upload-plugin -PN ansible
+      - run: ecosystem-test remote-upload-plugin -PN kubernetes
 
   run_virtual_machine_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b examples/blueprint-examples/virtual-machine/gcp.yaml --test-id=virtual-machine --on-failure=uninstall-force --timeout=1800 | tee -a run_virtual_machine_test.log
+      - run: ecosystem-test remote-blueprint-test  -b examples/blueprint-examples/virtual-machine/gcp.yaml --test-id=virtual-machine-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=1800 | tee -a run_virtual_machine_test.log
       - store_artifacts:
           path: run_virtual_machine_test.log
       - slack/notify_failed
 
   run_gke_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b examples/blueprint-examples/kubernetes/gcp-gke/blueprint.yaml --test-id=gcp-gke  -i resource_prefix=gcpresource-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_gke_test.log
+      - run: 
+          name: run_gke_test
+          no_output_timeout: 90m
+          command: ecosystem-test remote-blueprint-test  -b examples/blueprint-examples/kubernetes/gcp-gke/blueprint.yaml --test-id=gcp-gke-$CIRCLE_BUILD_NUM  -i resource_prefix=gcpresource-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_gke_test.log
       - store_artifacts:
           path: run_gke_test.log
       - slack/notify_failed
@@ -59,49 +86,49 @@ commands:
   # test blueprints
   run_attach_disk_test:
      steps:
-        - run: ecosystem-test local-blueprint-test  -b blueprints/attach-disk.yaml --test-id=gcp-attach-disk  -i zone=europe-west1-b -i region=europe-west1 -i prefix=gcp-attach-disk-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_attach_disk_test.log
+        - run: ecosystem-test remote-blueprint-test  -b blueprints/attach-disk.yaml --test-id=gcp-attach-disk-$CIRCLE_BUILD_NUM  -i zone=europe-west1-b -i region=europe-west1 -i prefix=gcp-attach-disk-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_attach_disk_test.log
         - store_artifacts:
             path: run_attach_disk_test.log
         - slack/notify_failed
 
   run_container_engine_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b blueprints/container-engine.yaml --test-id=gcp-container-engine -i prefix=gcp-container-engine-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_container_engine_test.log
+      - run: ecosystem-test remote-blueprint-test  -b blueprints/container-engine.yaml --test-id=gcp-container-engine-$CIRCLE_BUILD_NUM -i prefix=gcp-container-engine-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_container_engine_test.log
       - store_artifacts:
           path: run_container_engine_test.log
       - slack/notify_failed
 
   run_http_balancer_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b blueprints/http-balancer.yaml --test-id=gcp-http-balancer -i prefix=gcp-http-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_http_balancer_test.log
+      - run: ecosystem-test remote-blueprint-test  -b blueprints/http-balancer.yaml --test-id=gcp-http-balancer-$CIRCLE_BUILD_NUM -i prefix=gcp-http-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_http_balancer_test.log
       - store_artifacts:
           path: run_http_balancer_test.log
       - slack/notify_failed
 
   run_https_balancer_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b blueprints/https-balancer.yaml --test-id=gcp-https-balancer -i prefix=gcp-https-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_https_balancer_test.log
+      - run: ecosystem-test remote-blueprint-test  -b blueprints/https-balancer.yaml --test-id=gcp-https-balancer-$CIRCLE_BUILD_NUM -i prefix=gcp-https-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_https_balancer_test.log
       - store_artifacts:
           path: run_https_balancer_test.log
       - slack/notify_failed
 
   run_ssl_balancer_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b blueprints/ssl-balancer.yaml --test-id=gcp-ssl-balancer -i prefix=gcp-ssl-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_ssl_balancer_test.log
+      - run: ecosystem-test remote-blueprint-test  -b blueprints/ssl-balancer.yaml --test-id=gcp-ssl-balancer-$CIRCLE_BUILD_NUM -i prefix=gcp-ssl-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_ssl_balancer_test.log
       - store_artifacts:
           path: run_ssl_balancer_test.log
       - slack/notify_failed
 
   run_tcp_balancer_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b blueprints/tcp-balancer.yaml --test-id=gcp-tcp-balancer -i prefix=gcp-tcp-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_tcp_balancer_test.log
+      - run: ecosystem-test remote-blueprint-test  -b blueprints/tcp-balancer.yaml --test-id=gcp-tcp-balancer-$CIRCLE_BUILD_NUM -i prefix=gcp-tcp-balancer-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_tcp_balancer_test.log
       - store_artifacts:
           path: run_tcp_balancer_test.log
       - slack/notify_failed
 
   run_gcp_example_network_test:
     steps:
-      - run: ecosystem-test local-blueprint-test  -b examples/blueprint-examples/gcp-example-network/blueprint.yaml --test-id=gcp-example-network-test  -i resource_prefix=gcp-example-network-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_gcp_example_network_test.log
+      - run: ecosystem-test remote-blueprint-test  -b examples/blueprint-examples/gcp-example-network/blueprint.yaml --test-id=gcp-example-network-test-$CIRCLE_BUILD_NUM  -i resource_prefix=gcp-example-network-test-$CIRCLE_BUILD_NUM --on-failure=uninstall-force --timeout=3000 | tee -a run_gcp_example_network_test.log
       - store_artifacts:
           path: run_gcp_example_network_test.log
       - slack/notify_failed

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.9.5: 
+  - add remote manager & unique id to tests.
+  - Support waiting until the resource is ready.
 1.9.4: updated circleci to use context for env variables.
 1.9.3: fixed relationships validation of subnetworks.
 1.9.2: Use DSL 1.5 plugin yaml.

--- a/blueprints/container-engine.yaml
+++ b/blueprints/container-engine.yaml
@@ -36,7 +36,7 @@ node_templates:
   k8s_cluster:
     type: cloudify.gcp.nodes.KubernetesCluster
     properties:
-      name: demo-eaas
+      name: { concat: [ { get_input: prefix }, demo-eaas ] }
       gcp_config: *gcp_config
 
   k8s_node_pool:

--- a/cloudify_gcp/__version__.py
+++ b/cloudify_gcp/__version__.py
@@ -1,1 +1,1 @@
-version = '1.9.4'
+version = '1.9.5'

--- a/cloudify_gcp/utils.py
+++ b/cloudify_gcp/utils.py
@@ -179,7 +179,23 @@ def create_resource(func):
 
 @create_resource
 def create(resource):
-    return resource.create()
+    result = resource.create()
+    while True:
+        try:
+            created = resource.get()
+            if created:
+                break
+        except HttpError as e:
+            if e.resp.status == http_client.NOT_FOUND:
+                ctx.logger.info('Waiting for the resource to exist.')
+                time.sleep(3)
+            else:
+                raise e
+        except Exception as error:
+            ctx.logger.error('Error Message {0}'.format(error))
+            break
+
+    return result
 
 
 def runtime_properties_cleanup(ctx):
@@ -406,6 +422,7 @@ def get_node(_ctx, target=False):
         return _ctx.node
 
 
+# flake8: noqa: C901
 def get_gcp_config(node=None, requested_zone=None):
 
     node = node or get_node(ctx)

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,0 @@
-pyrsistent==0.16.1
-networkx==1.9.1
-cloudify>=6.4
-cryptography==3.3.2
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,0 @@
-dnspython
-pyopenssl
-pycryptodome==3.9.8

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -2,7 +2,7 @@ plugins:
   gcp_plugin:
     executor: central_deployment_agent
     package_name: cloudify-gcp-plugin
-    package_version: 1.9.4
+    package_version: 1.9.5
 dsl_definitions:
   use_external_resource_desc: >
     Indicate whether the resource exists or if Cloudify should create the resource, true if you are bringing an existing resource, false if you want cloudify to create it.

--- a/plugin_1_5.yaml
+++ b/plugin_1_5.yaml
@@ -3,7 +3,7 @@ plugins:
   gcp_plugin:
     executor: central_deployment_agent
     package_name: cloudify-gcp-plugin
-    package_version: 1.9.4
+    package_version: 1.9.5
     properties_description: Manage Azure resources.
     properties:
       auth:

--- a/python311.patch
+++ b/python311.patch
@@ -1,13 +1,20 @@
+diff --git a/constraints.txt b/constraints.txt
+index e69de29..087a8c1 100644
+--- a/constraints.txt
++++ b/constraints.txt
+@@ -0,0 +1 @@
++cloudify-common>=7.0.0
+\ No newline at end of file
 diff --git a/setup.py b/setup.py
-index 0149077..e574d05 100644
+index 01ef3c7..94e090d 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -47,7 +47,7 @@ setup(
+@@ -48,7 +48,7 @@ setup(
      install_requires=[
          "oauth2client==4.1.3",
          "google-auth==2.15.0",
--        "google-api-python-client==2.52.0.",
-+        "google-api-python-client==2.92.0",
-         "cloudify-common>=4.5.5",
-         'cloudify-utilities-plugins-sdk>=0.0.61',
-         "networkx==1.9.1",
+-        "google-api-python-client>=2.52.0",
++        "google-api-python-client>=2.92.0",
+         "cloudify-common>=6.3.1",
+         'cloudify-utilities-plugins-sdk>=0.0.124',
+         "pycryptodome>=3.9.8,<3.10",

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ from setuptools import setup
 
 def get_version():
     current_dir = pathlib.Path(__file__).parent.resolve()
-    with open(os.path.join(current_dir,'cloudify_gcp/__version__.py'),
-              'r') as outfile:
+    with open(os.path.join(
+            current_dir,
+            'cloudify_gcp/__version__.py'), 'r') as outfile:
         var = outfile.read()
         return re.search(r'\d+.\d+.\d+', var).group()
 
@@ -47,10 +48,9 @@ setup(
     install_requires=[
         "oauth2client==4.1.3",
         "google-auth==2.15.0",
-        "google-api-python-client==2.52.0.",
-        "cloudify-common>=4.5.5",
-        'cloudify-utilities-plugins-sdk>=0.0.61',
-        "networkx==1.9.1",
+        "google-api-python-client>=2.52.0",
+        "cloudify-common>=6.3.1",
+        'cloudify-utilities-plugins-sdk>=0.0.124',
         "pycryptodome>=3.9.8,<3.10",
         "jsonschema==3.0.0",
         'httplib2>=0.18.0'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,7 @@
-flake8
-dnspython
 mock
 pyopenssl
-pytest==4.6.3
+pytest
 testfixtures
 pytest-cov
 nose
-rsa==4.5
+flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,11 @@
-[coverage:run]
-branch = True
-source =
-    cloudify_gcp
-
-[coverage:report]
-show_missing = True
-
-
 [tox]
-envlist=linting,unittesting
+envlist = unittesting,linting
+minversion = 1.6
+skipsdist = True
 
 [testenv]
 setenv =
         VIRTUAL_ENV={envdir}
-
-# NOTE: relative paths were used due to '-w' flag for nosetests util
 
 usedevelop = True
 install_command = pip install -U {opts} {packages}
@@ -22,28 +13,23 @@ deps = -r{toxinidir}/dev-requirements.txt
        -r{toxinidir}/test-requirements.txt
 whitelist_externals = bash
 
+[testenv:flake8]
+commands =
+    flake8 cloudify_gcp setup.py
+
+[testenv:linting]
+skip_install = true
+commands =
+    {[testenv:flake8]commands}
+
 [testenv:unittesting]
-deps =
-    testfixtures
-    pytest-cov
-    -rtest-requirements.txt
-commands=
+commands =
     coverage run -m pytest cloudify_gcp {posargs}
     coverage report
 
-
-[testenv:linting]
-deps =
-    flake8
-    -rtest-requirements.txt
-commands=flake8 cloudify_gcp --ignore=E123,E126
-
-
-[testenv:venv]
-commands = {posargs}
-
-[linting]
-show-source = True
-ignore =
-exclude=.venv,.tox,dist,*egg,etc,build,bin,lib,local,share
-filename=*.py
+[flake8]
+extend-ignore = E203
+per-file-ignores =
+    src/flake8/formatting/_windows_color.py: N806
+    tests/*: D
+max-complexity = 10

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -2,7 +2,7 @@ plugins:
   gcp_plugin:
     executor: central_deployment_agent
     package_name: cloudify-gcp-plugin
-    package_version: 1.9.4
+    package_version: 1.9.5
 dsl_definitions:
   use_external_resource_desc: >
     Indicate whether the resource exists or if Cloudify should create the resource, true if you are bringing an existing resource, false if you want cloudify to create it.


### PR DESCRIPTION
* add remote manager & uniqe id to each test in order to prever multiple test sharing an id

* fix k8s_cluster name in blueprint container-engine.yaml prefix + demo-eaas

* Support waiting until the resource is ready (in utils.create)

* update version

* fix SIGTERM

* change test config in tox ini

* test tox again

* try this

* try this

* trying with pylint

* pep8

* pep8

* test something

* return usedevelop

* python365

* add 311 patch

* add back usedevelop

---------